### PR TITLE
Use environment defaults for seeding script

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
   "name": "mysql-python-codespace",
   "dockerComposeFile": "../docker-compose.yml",
   "service": "workspace",
-  "workspaceFolder": "/workspaces",
+  "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename:-workspace}",
   "forwardPorts": [
     3306
   ],
@@ -17,7 +17,7 @@
     "MYSQL_PORT": "3306",
     "MYSQL_USER": "app_user",
     "MYSQL_PASSWORD": "app_password",
-    "MYSQL_DATABASE": "airports"
+    "MYSQL_DATABASE": "travelops_db"
   },
   "customizations": {
     "vscode": {

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ Spin up a Codespace with MySQL 8 and Python ready to seed a realistic travel dat
    ```bash
    mysql -h "$MYSQL_HOST" -P "$MYSQL_PORT" -u "$MYSQL_USER" -p"$MYSQL_PASSWORD" "$MYSQL_DATABASE" -e "SELECT VERSION();"
    ```
-4. **Seed data** using your provided script:
+4. **Seed data** using your provided script (connection details are read from environment variables):
    ```bash
-   python app/seed_travelops_mysql.py --user "$MYSQL_USER" --password "$MYSQL_PASSWORD" --database "$MYSQL_DATABASE" --host "$MYSQL_HOST" --port "$MYSQL_PORT" --reset --customers 300 --airports 25 --days 30 --partial-payments
+   python app/seed_airports_mysql.py --reset --customers 300 --airports 25 --days 30 --partial-payments
    ```
    Re-run without `--reset` to add more data later.
 5. **Run example queries**:
@@ -22,7 +22,7 @@ Spin up a Codespace with MySQL 8 and Python ready to seed a realistic travel dat
 ## How it works
 - MySQL service is defined in `docker-compose.yml` and seeded with `app/schema.sql` on first start.
 - Environment vars are provided by `.devcontainer/devcontainer.json` so your scripts don't need to hardcode connection settings.
-- Your original `seed_travelops_mysql.py` drives all data generation.
+- Your original `seed_airports_mysql.py` drives all data generation.
 
 ## Resetting the DB
 - Stop the Codespace (or Dev Container), then remove the `mysql-data` volume locally if needed.

--- a/app/seed_airports_mysql.py
+++ b/app/seed_airports_mysql.py
@@ -4,6 +4,7 @@ Seed the airports MySQL schema with synthetic data.
 (See comments inside for usage and options.)
 """
 import argparse
+import os
 import random
 import sys
 from datetime import datetime, timedelta
@@ -61,12 +62,14 @@ EMAIL_DOMAINS = ["example.com","mail.com","gmail.com","outlook.com","yahoo.com"]
 PAY_METHODS = ["CARD","PAYPAL","VOUCHER","BANK_TRANSFER"]
 
 def parse_args():
+    """Parse CLI arguments using environment variables as defaults."""
+
     p = argparse.ArgumentParser(description="Seed TravelOps MySQL data")
-    p.add_argument("--host", default="127.0.0.1")
-    p.add_argument("--port", type=int, default=3306)
-    p.add_argument("--user", required=True)
-    p.add_argument("--password", required=True)
-    p.add_argument("--database", required=True)
+    p.add_argument("--host", default=os.getenv("MYSQL_HOST", "127.0.0.1"))
+    p.add_argument("--port", type=int, default=int(os.getenv("MYSQL_PORT", "3306")))
+    p.add_argument("--user", default=os.getenv("MYSQL_USER"))
+    p.add_argument("--password", default=os.getenv("MYSQL_PASSWORD"))
+    p.add_argument("--database", default=os.getenv("MYSQL_DATABASE"))
     p.add_argument("--reset", action="store_true", help="Truncate tables before seeding (FK-safe order)")
     p.add_argument("--airports", type=int, default=20, help="Target number of airports")
     p.add_argument("--customers", type=int, default=300, help="Target number of customers")
@@ -79,7 +82,17 @@ def parse_args():
     p.add_argument("--partial-payments", action="store_true", help="Allow partial prepayments for PENDING bookings")
     p.add_argument("--currency", default="GBP", help="Currency code for payments (3 letters)")
     p.add_argument("--seed", type=int, default=42, help="Random seed for reproducibility")
-    return p.parse_args()
+
+    args = p.parse_args()
+
+    # Ensure required connection details are present either via args or env vars
+    missing = [name for name in ("user", "password", "database") if getattr(args, name) is None]
+    if missing:
+        p.error(
+            "--user/--password/--database required (or set MYSQL_USER, MYSQL_PASSWORD, MYSQL_DATABASE)"
+        )
+
+    return args
 
 def connect(args):
     conn = mysql.connect(
@@ -153,7 +166,7 @@ def generate_name_email(fake: Optional['Faker'], idx: int) -> Tuple[str,str,str]
         return first, last, email.lower()
     first = random.choice(FIRST_NAMES)
     last  = random.choice(LAST_NAMES)
-    email = f\"{first}.{last}.{idx}@{random.choice(EMAIL_DOMAINS)}\".lower()
+    email = f"{first}.{last}.{idx}@{random.choice(EMAIL_DOMAINS)}".lower()
     return first, last, email
 
 def ensure_customers(conn, target_customers: int, seed: int):


### PR DESCRIPTION
## Summary
- let MySQL seeding script read connection info from env vars and validate
- clarify README usage to rely on env-provided connection details
- fix synthetic email generation quoting
- correct Codespaces devcontainer to mount repo workspace and align default database name

## Testing
- `python -m py_compile app/seed_airports_mysql.py`
- ⚠️ `python app/seed_airports_mysql.py --help` (missing mysql-connector-python, installation blocked)


------
https://chatgpt.com/codex/tasks/task_e_68b946203d0c83308036c759167e0282